### PR TITLE
Fix tile hotbar using incorrect index

### DIFF
--- a/objects/obj_ev_placeable_drag/Draw_0.gml
+++ b/objects/obj_ev_placeable_drag/Draw_0.gml
@@ -1,5 +1,11 @@
 
-var tile = global.editor_instance.current_list[object_ind]
+var tile;
+if(global.tile_mode) {
+	tile = global.editor_instance.current_list[tile_ind]
+} else {
+	tile = global.editor_instance.current_list[object_ind]
+}
+
 if (tile == global.editor_instance.object_player)
 	sprite_index = ev_get_stranger_down_sprite(global.stranger)
 else


### PR DESCRIPTION
aka "make the hotbar in tile mode actually use the tile number instead of the object number"

This fixes two issues at once:

1. Editing the tile hotbar didn't visually update it in the tile selection window
    * However, editing the *entity* hotbar *would* cause a change in the tile hotbar
2. Selecting an entity beyond the bounds of the tiles, then switching to tile mode and opening the selection window crashed the game