### PR TITLE
Add the endless void rod as a chest content option

### DIFF
--- a/objects/obj_ev_chest_window/Create_0.gml
+++ b/objects/obj_ev_chest_window/Create_0.gml
@@ -1,7 +1,7 @@
 event_inherited()
 
 selector = instance_create_layer(112, 72, "WindowElements", asset_get_index("obj_ev_selector"), {
-	elements : ["Locust", "Memory", "Wings", "Sword", "Empty", "Opened", "Idol"],
+	elements : ["Locust", "Memory", "Wings", "Sword", "Empty", "Opened", "Idol", "Endless"],
 	
 	selected_element : chest_properties.itm,
 	max_radius : 60
@@ -16,7 +16,8 @@ function get_item_name(item_id) {
 		case chest_items.wings: return "Wings";
 		case chest_items.sword: return "Sword";
 		case chest_items.opened: return "Opened";
-		case chest_items.swapper: return "Idol";		
+		case chest_items.swapper: return "Idol";
+		case chest_items.endless: return "Endless";
 		default: return "IDK";
 	}
 }

--- a/objects/obj_ev_credits/Draw_0.gml
+++ b/objects/obj_ev_credits/Draw_0.gml
@@ -58,6 +58,7 @@ Pyredrid - Branefuck functions
 Meepster99 - GBAStranger export
 gullwingdoors - Pencil icon
 juliascythe - Helping with 3D cube rendering and the Grube
+cyrelouyea - Endless void rod option in chests
 
 Music Credits:
 Sunday - crappyblue - astra_jam (...ad astra)

--- a/objects/obj_ev_editor/Create_0.gml
+++ b/objects/obj_ev_editor/Create_0.gml
@@ -580,6 +580,7 @@ enum chest_items {
 	empty,
 	opened,
 	swapper,
+	endless,
 	size // cool trick!
 }
 
@@ -615,7 +616,8 @@ function chest_get_contents_num(item_id) {
 		case chest_items.sword: return 2;
 		case chest_items.empty: return 0;
 		case chest_items.opened: return 5;
-		case chest_items.swapper: return 495;		
+		case chest_items.swapper: return 495;
+		case chest_items.endless: return 7;
 		default: return 1;
 	}
 }


### PR DESCRIPTION
Surprisingly, content number 7 was already configured in `gml_Object_obj_chest_small_Alarm_0`  to contain the endless rod for some reason.